### PR TITLE
feat: add @PluginProperty group annotations

### DIFF
--- a/src/main/java/io/kestra/plugin/opensearch/AbstractLoad.java
+++ b/src/main/java/io/kestra/plugin/opensearch/AbstractLoad.java
@@ -42,7 +42,7 @@ public abstract class AbstractLoad extends AbstractTask implements RunnableTask<
         description = "Path to Kestra internal storage object containing line-delimited JSON or ION records."
     )
     @NotNull
-    @PluginProperty(internalStorageURI = true)
+    @PluginProperty(internalStorageURI = true, group = "main")
     private Property<String> from;
 
     @Schema(
@@ -50,6 +50,7 @@ public abstract class AbstractLoad extends AbstractTask implements RunnableTask<
         description = "Number of operations per bulk request; defaults to 1000."
     )
     @Builder.Default
+    @PluginProperty(group = "execution")
     private Property<Integer> chunk = Property.ofValue(1000);
 
     protected abstract Flux<BulkOperation> source(RunContext runContext, BufferedReader inputStream) throws IllegalVariableEvaluationException, IOException;

--- a/src/main/java/io/kestra/plugin/opensearch/AbstractSearch.java
+++ b/src/main/java/io/kestra/plugin/opensearch/AbstractSearch.java
@@ -36,13 +36,14 @@ public abstract class AbstractSearch extends AbstractTask {
         title = "Target indices",
         description = "Optional list of indices; defaults to all when empty."
     )
+    @PluginProperty(group = "advanced")
     private Property<List<String>> indexes;
 
     @Schema(
         title = "Search request payload",
         description = "JSON string or Map rendered then parsed into an OpenSearch SearchRequest."
     )
-    @PluginProperty(dynamic = true)
+    @PluginProperty(dynamic = true, group = "advanced")
     private Object request;
 
     @Schema(
@@ -50,6 +51,7 @@ public abstract class AbstractSearch extends AbstractTask {
         description = "Format used to parse string requests; defaults to JSON."
     )
     @Builder.Default
+    @PluginProperty(group = "advanced")
     private Property<XContentType> contentType = Property.ofValue(XContentType.JSON); //FIXME
 
     protected SearchRequest.Builder request(RunContext runContext, OpenSearchTransport transport) throws IllegalVariableEvaluationException, IOException {

--- a/src/main/java/io/kestra/plugin/opensearch/AbstractTask.java
+++ b/src/main/java/io/kestra/plugin/opensearch/AbstractTask.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -19,11 +20,13 @@ public abstract class AbstractTask extends Task {
         description = "Hosts, auth headers, and TLS options reused by every task invocation."
     )
     @NotNull
+    @PluginProperty(group = "main")
     protected OpensearchConnection connection;
 
     @Schema(
         title = "Shard routing key",
         description = "Hashes routing using this value instead of the document id to colocate related records."
     )
+    @PluginProperty(group = "advanced")
     protected Property<String> routing;
 }

--- a/src/main/java/io/kestra/plugin/opensearch/Get.java
+++ b/src/main/java/io/kestra/plugin/opensearch/Get.java
@@ -18,6 +18,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -54,12 +55,14 @@ public class Get extends AbstractTask implements RunnableTask<Get.Output> {
         title = "Target OpenSearch index"
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> index;
 
     @Schema(
         title = "Document id"
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> key;
 
     @Schema(
@@ -67,6 +70,7 @@ public class Get extends AbstractTask implements RunnableTask<Get.Output> {
         description = "Request fails if the cluster version differs; use for optimistic concurrency."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<Long> docVersion;
 
     @Override

--- a/src/main/java/io/kestra/plugin/opensearch/Load.java
+++ b/src/main/java/io/kestra/plugin/opensearch/Load.java
@@ -23,6 +23,7 @@ import lombok.experimental.SuperBuilder;
 import reactor.core.publisher.Flux;
 
 import static io.kestra.core.utils.Rethrow.throwFunction;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -63,18 +64,21 @@ public class Load extends AbstractLoad implements RunnableTask<Load.Output> {
         title = "Target OpenSearch index"
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> index;
 
     @Schema(
         title = "Bulk operation type",
         description = "Indexing op type; INDEX/CREATE supported, others rejected by client."
     )
+    @PluginProperty(group = "advanced")
     private Property<OpType> opType;
 
     @Schema(
         title = "Field to use as document id",
         description = "If set, uses this field value as `_id`; field is removed when `removeIdKey` is true."
     )
+    @PluginProperty(group = "connection")
     private Property<String> idKey;
 
     @Schema(
@@ -82,6 +86,7 @@ public class Load extends AbstractLoad implements RunnableTask<Load.Output> {
         description = "Defaults to true; keep the id field in the document by setting to false."
     )
     @Builder.Default
+    @PluginProperty(group = "connection")
     private Property<Boolean> removeIdKey = Property.ofValue(true);
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/io/kestra/plugin/opensearch/OpensearchConnection.java
+++ b/src/main/java/io/kestra/plugin/opensearch/OpensearchConnection.java
@@ -50,36 +50,41 @@ public class OpensearchConnection {
         description = "One or more host URLs with scheme and port, e.g. `https://opensearch.com:9200`; all are used for load-balancing/failover."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<List<String>> hosts;
 
     @Schema(
         title = "Basic auth configuration"
     )
-    @PluginProperty(dynamic = false)
+    @PluginProperty(dynamic = false, group = "advanced")
     private BasicAuth basicAuth;
 
     @Schema(
         title = "Additional HTTP headers",
         description = "Each entry is `Key:Value`, e.g. `Authorization: Token XYZ`; rendered per request."
     )
+    @PluginProperty(group = "advanced")
     private Property<List<String>> headers;
 
     @Schema(
         title = "Path prefix for every request",
         description = "Prepends `/my/path` to all endpoints when OpenSearch is behind a proxy enforcing a base path; leave unset otherwise."
     )
+    @PluginProperty(group = "advanced")
     private Property<String> pathPrefix;
 
     @Schema(
         title = "Fail on warning headers",
         description = "If true, any response containing an OpenSearch warning header is treated as a failure; defaults to server/client behavior."
     )
+    @PluginProperty(group = "advanced")
     private Property<Boolean> strictDeprecationMode;
 
     @Schema(
         title = "Trust all SSL certificates",
         description = "Disables TLS verification for self-signed clusters; insecure, use only in trusted networks."
     )
+    @PluginProperty(group = "advanced")
     private Property<Boolean> trustAllSsl;
 
     @SuperBuilder
@@ -89,11 +94,13 @@ public class OpensearchConnection {
         @Schema(
             title = "Basic auth username"
         )
+        @PluginProperty(group = "connection")
         private Property<String> username;
 
         @Schema(
             title = "Basic auth password"
         )
+        @PluginProperty(group = "connection")
         private Property<String> password;
     }
 

--- a/src/main/java/io/kestra/plugin/opensearch/Put.java
+++ b/src/main/java/io/kestra/plugin/opensearch/Put.java
@@ -92,24 +92,27 @@ public class Put extends AbstractTask implements RunnableTask<Put.Output> {
         title = "Target OpenSearch index"
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> index;
 
     @Schema(
         title = "Operation type",
         description = "INDEX or CREATE are supported; others are rejected."
     )
+    @PluginProperty(group = "advanced")
     private Property<OpType> opType;
 
     @Schema(
         title = "Document id"
     )
+    @PluginProperty(group = "connection")
     private Property<String> key;
 
     @Schema(
         title = "Document body",
         description = "String rendered then parsed using `contentType`, or a Map rendered and sent as JSON."
     )
-    @PluginProperty(dynamic = true)
+    @PluginProperty(dynamic = true, group = "advanced")
     private Object value;
 
     @Schema(
@@ -117,6 +120,7 @@ public class Put extends AbstractTask implements RunnableTask<Put.Output> {
         description = "IMMEDIATE forces refresh, WAIT_UNTIL waits for refresh, NONE (default) leaves refresh to cluster."
     )
     @Builder.Default
+    @PluginProperty(group = "advanced")
     private Property<RefreshPolicy> refreshPolicy = Property.ofValue(RefreshPolicy.NONE);
 
     @Schema(
@@ -124,6 +128,7 @@ public class Put extends AbstractTask implements RunnableTask<Put.Output> {
         description = "Format used when `value` is a string; defaults to JSON."
     )
     @Builder.Default
+    @PluginProperty(group = "advanced")
     private Property<XContentType> contentType = Property.ofValue(XContentType.JSON);
 
     @Override

--- a/src/main/java/io/kestra/plugin/opensearch/Request.java
+++ b/src/main/java/io/kestra/plugin/opensearch/Request.java
@@ -98,6 +98,7 @@ public class Request extends AbstractTask implements RunnableTask<Request.Output
         description = "Defaults to GET when not set."
     )
     @Builder.Default
+    @PluginProperty(group = "advanced")
     protected Property<HttpMethod> method = Property.ofValue(HttpMethod.GET);
 
     @Schema(
@@ -105,18 +106,20 @@ public class Request extends AbstractTask implements RunnableTask<Request.Output
         description = "Endpoint without scheme/host/port; pathPrefix from the connection is prepended automatically."
     )
     @NotNull
+    @PluginProperty(group = "main")
     protected Property<String> endpoint;
 
     @Schema(
         title = "Query string parameters"
     )
+    @PluginProperty(group = "main")
     protected Property<Map<String, String>> parameters;
 
     @Schema(
         title = "Request body",
         description = "Accepts a JSON string or Map rendered then serialized as JSON."
     )
-    @PluginProperty(dynamic = true)
+    @PluginProperty(dynamic = true, group = "main")
     protected Object body;
 
     @Override

--- a/src/main/java/io/kestra/plugin/opensearch/Search.java
+++ b/src/main/java/io/kestra/plugin/opensearch/Search.java
@@ -30,6 +30,7 @@ import lombok.experimental.SuperBuilder;
 import reactor.core.publisher.Flux;
 
 import static io.kestra.core.utils.Rethrow.throwConsumer;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -71,6 +72,7 @@ public class Search extends AbstractSearch implements RunnableTask<Search.Output
         description = "FETCH returns all rows, FETCH_ONE returns the first row, STORE saves rows to Internal Storage, NONE skips output; defaults to FETCH."
     )
     @Builder.Default
+    @PluginProperty(group = "processing")
     private Property<FetchType> fetchType = Property.ofValue(FetchType.FETCH);
 
     @Override


### PR DESCRIPTION
## Summary

Add `@PluginProperty(group = "...")` annotations to task properties following the 9-group taxonomy (`main`, `connection`, `source`, `processing`, `execution`, `destination`, `reliability`, `advanced`, `deprecated`).

These annotations drive section grouping in the Kestra NoCode UI editor.

Groups are assigned from a curated CSV of 8,798 property assignments across 925 task types, with heuristic fallback for properties not in the CSV.

Part-of: https://github.com/kestra-io/kestra-ee/issues/6712