### PR TITLE
fix(core): migrate FileSerde to InputStream/OutputStream API for binary ION support

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 version=1.4.3-SNAPSHOT
-kestraVersion=1.3.13
+kestraVersion=1.3.19

--- a/src/main/java/io/kestra/plugin/opensearch/AbstractLoad.java
+++ b/src/main/java/io/kestra/plugin/opensearch/AbstractLoad.java
@@ -1,8 +1,8 @@
 package io.kestra.plugin.opensearch;
 
-import java.io.BufferedReader;
+import java.io.BufferedInputStream;
 import java.io.IOException;
-import java.io.InputStreamReader;
+import java.io.InputStream;
 import java.net.URI;
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicLong;
@@ -53,7 +53,7 @@ public abstract class AbstractLoad extends AbstractTask implements RunnableTask<
     @PluginProperty(group = "execution")
     private Property<Integer> chunk = Property.ofValue(1000);
 
-    protected abstract Flux<BulkOperation> source(RunContext runContext, BufferedReader inputStream) throws IllegalVariableEvaluationException, IOException;
+    protected abstract Flux<BulkOperation> source(RunContext runContext, InputStream inputStream) throws IllegalVariableEvaluationException, IOException;
 
     @Override
     public Output run(RunContext runContext) throws Exception {
@@ -62,7 +62,7 @@ public abstract class AbstractLoad extends AbstractTask implements RunnableTask<
 
         try (
             RestClientTransport transport = this.connection.client(runContext);
-            BufferedReader inputStream = new BufferedReader(new InputStreamReader(runContext.storage().getFile(from)), FileSerde.BUFFER_SIZE)
+            InputStream inputStream = new BufferedInputStream(runContext.storage().getFile(from), FileSerde.BUFFER_SIZE)
         ) {
             OpenSearchClient client = new OpenSearchClient(transport);
             AtomicLong count = new AtomicLong();

--- a/src/main/java/io/kestra/plugin/opensearch/Bulk.java
+++ b/src/main/java/io/kestra/plugin/opensearch/Bulk.java
@@ -2,6 +2,8 @@ package io.kestra.plugin.opensearch;
 
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.util.Map;
 import java.util.function.Consumer;
 
@@ -70,9 +72,9 @@ public class Bulk extends AbstractLoad implements RunnableTask<Bulk.Output> {
     private static final ObjectMapper OBJECT_MAPPER = JacksonMapper.ofJson();
 
     @Override
-    protected Flux<BulkOperation> source(RunContext runContext, BufferedReader inputStream) throws IOException {
+    protected Flux<BulkOperation> source(RunContext runContext, InputStream inputStream) throws IOException {
         return Flux
-            .create(this.fileReader(inputStream), FluxSink.OverflowStrategy.BUFFER);
+            .create(this.fileReader(new BufferedReader(new InputStreamReader(inputStream))), FluxSink.OverflowStrategy.BUFFER);
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/io/kestra/plugin/opensearch/Load.java
+++ b/src/main/java/io/kestra/plugin/opensearch/Load.java
@@ -1,7 +1,7 @@
 package io.kestra.plugin.opensearch;
 
-import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Map;
 
 import org.opensearch.client.opensearch.core.bulk.BulkOperation;
@@ -10,6 +10,7 @@ import org.opensearch.client.opensearch.core.bulk.IndexOperation;
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.runners.RunContext;
@@ -23,7 +24,6 @@ import lombok.experimental.SuperBuilder;
 import reactor.core.publisher.Flux;
 
 import static io.kestra.core.utils.Rethrow.throwFunction;
-import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -91,7 +91,7 @@ public class Load extends AbstractLoad implements RunnableTask<Load.Output> {
 
     @SuppressWarnings("unchecked")
     @Override
-    protected Flux<BulkOperation> source(RunContext runContext, BufferedReader inputStream) throws IllegalVariableEvaluationException, IOException {
+    protected Flux<BulkOperation> source(RunContext runContext, InputStream inputStream) throws IllegalVariableEvaluationException, IOException {
         return FileSerde.readAll(inputStream)
             .map(throwFunction(o ->
             {

--- a/src/main/java/io/kestra/plugin/opensearch/Ppl.java
+++ b/src/main/java/io/kestra/plugin/opensearch/Ppl.java
@@ -1,8 +1,8 @@
 package io.kestra.plugin.opensearch;
 
-import java.io.BufferedWriter;
+import java.io.BufferedOutputStream;
 import java.io.File;
-import java.io.FileWriter;
+import java.io.FileOutputStream;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -162,7 +162,8 @@ public class Ppl extends AbstractTask implements RunnableTask<Ppl.Output> {
 
         List<String> columns = schema.stream().map(s -> (String) s.get("name")).toList();
         List<Map<String, Object>> rows = datarows.stream()
-            .map(values -> {
+            .map(values ->
+            {
                 Map<String, Object> row = new LinkedHashMap<>();
                 for (int i = 0; i < columns.size() && i < values.size(); i++) {
                     row.put(columns.get(i), values.get(i));
@@ -178,8 +179,8 @@ public class Ppl extends AbstractTask implements RunnableTask<Ppl.Output> {
             case FETCH_ONE -> builder.row(rows.isEmpty() ? null : rows.getFirst()).size(rows.isEmpty() ? 0 : 1);
             case STORE -> {
                 File tempFile = runContext.workingDir().createTempFile(".ion").toFile();
-                try (var writer = new BufferedWriter(new FileWriter(tempFile), FileSerde.BUFFER_SIZE)) {
-                    Long count = FileSerde.writeAll(writer, Flux.fromIterable(rows)).block();
+                try (var output = new BufferedOutputStream(new FileOutputStream(tempFile), FileSerde.BUFFER_SIZE)) {
+                    Long count = FileSerde.writeAll(output, Flux.fromIterable(rows)).block();
                     builder.uri(runContext.storage().putFile(tempFile)).size(count == null ? 0 : count.intValue());
                 }
             }
@@ -200,7 +201,8 @@ public class Ppl extends AbstractTask implements RunnableTask<Ppl.Output> {
                 Files.writeString(tempFile.toPath(), content, StandardCharsets.UTF_8);
                 builder.uri(runContext.storage().putFile(tempFile));
             }
-            case NONE -> { }
+            case NONE -> {
+            }
         }
 
         return builder.build();

--- a/src/main/java/io/kestra/plugin/opensearch/Scroll.java
+++ b/src/main/java/io/kestra/plugin/opensearch/Scroll.java
@@ -71,7 +71,7 @@ public class Scroll extends AbstractSearch implements RunnableTask<Scroll.Output
 
         try (
             RestClientTransport transport = this.connection.client(runContext);
-            Writer output = new BufferedWriter(new FileWriter(tempFile), FileSerde.BUFFER_SIZE)
+            OutputStream output = new BufferedOutputStream(new FileOutputStream(tempFile), FileSerde.BUFFER_SIZE)
         ) {
             OpenSearchClient client = new OpenSearchClient(transport);
             // build request

--- a/src/main/java/io/kestra/plugin/opensearch/Search.java
+++ b/src/main/java/io/kestra/plugin/opensearch/Search.java
@@ -16,6 +16,7 @@ import org.slf4j.Logger;
 
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.executions.metrics.Counter;
 import io.kestra.core.models.executions.metrics.Timer;
 import io.kestra.core.models.property.Property;
@@ -30,7 +31,6 @@ import lombok.experimental.SuperBuilder;
 import reactor.core.publisher.Flux;
 
 import static io.kestra.core.utils.Rethrow.throwConsumer;
-import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -128,7 +128,7 @@ public class Search extends AbstractSearch implements RunnableTask<Search.Output
     protected Pair<URI, Long> store(RunContext runContext, SearchResponse<Map> searchResponse) throws IOException {
         File tempFile = runContext.workingDir().createTempFile(".ion").toFile();
 
-        try (var output = new BufferedWriter(new FileWriter(tempFile), FileSerde.BUFFER_SIZE)) {
+        try (var output = new BufferedOutputStream(new FileOutputStream(tempFile), FileSerde.BUFFER_SIZE)) {
             Flux<Map> hitFlux = Flux.fromIterable(searchResponse.hits().hits()).map(hit -> hit.source());
             Long count = FileSerde.writeAll(output, hitFlux).block();
 

--- a/src/test/java/io/kestra/plugin/opensearch/SearchTest.java
+++ b/src/test/java/io/kestra/plugin/opensearch/SearchTest.java
@@ -117,9 +117,9 @@ class SearchTest {
         assertThat(run.getTotal(), is(28L));
         assertThat(run.getUri(), notNullValue());
 
-        BufferedReader inputStream = new BufferedReader(new InputStreamReader(storageInterface.get(TenantService.MAIN_TENANT, null, run.getUri())));
+        InputStream inputStream = new BufferedInputStream(storageInterface.get(TenantService.MAIN_TENANT, null, run.getUri()));
         List<Map<String, Object>> result = new ArrayList<>();
-        FileSerde.reader(inputStream, r -> result.add((Map<String, Object>) r));
+        FileSerde.read(inputStream, r -> result.add((Map<String, Object>) r));
 
         assertThat(result.get(8).get("key"), is(925311404));
     }


### PR DESCRIPTION
Migrate deprecated Reader/Writer-based FileSerde API to InputStream/OutputStream for binary ION compatibility (kestra/kestra#3155).

**Changes:**
- `gradle.properties`: bump `kestraVersion` from 1.3.13 to 1.3.19
- `AbstractLoad.java`: `BufferedReader`/`InputStreamReader` → `BufferedInputStream`/`InputStream`
- `Load.java`: `BufferedReader` parameter → `InputStream`
- `Bulk.java`: `BufferedReader` parameter → `InputStream` (wraps internally for line reading)
- `Search.java`: `BufferedWriter`/`FileWriter` → `BufferedOutputStream`/`FileOutputStream`
- `Ppl.java`: `BufferedWriter`/`FileWriter` → `BufferedOutputStream`/`FileOutputStream`
- `Scroll.java`: `Writer`/`BufferedWriter`/`FileWriter` → `OutputStream`/`BufferedOutputStream`/`FileOutputStream`
- `SearchTest.java`: `BufferedReader`/`FileSerde.reader()` → `BufferedInputStream`/`FileSerde.read()`